### PR TITLE
replace svelte option in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
 	"name": "@peerpiper/qrcode-scanner-svelte",
 	"version": "1.0.6",
-	"svelte": "index.js",
+	"exports": {
+	  	".": {
+	     	"svelte": "./dist/index.js"
+		}
+	},
 	"main": "index.js",
 	"module": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
 	"version": "1.0.6",
 	"exports": {
 		".": {
-			"svelte": "index.js"
+			"import": "./src/lib/index.js",
+			"require": "./src/lib/index.js",
+			"svelte": "./src/lib/index.js"
 		}
 	},
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "@peerpiper/qrcode-scanner-svelte",
 	"version": "1.0.6",
 	"exports": {
-	  	".": {
-	     	"svelte": "./dist/index.js"
+		".": {
+			"svelte": "index.js"
 		}
 	},
 	"main": "index.js",


### PR DESCRIPTION
Fixes #2 

Replaced the svelte option in package.json as per https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition